### PR TITLE
Add repository section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,9 @@
 	"homepage": "https://github.com/rmustacc/node-ctype",
 	"author": "Robert Mustacchi <rm@fingolfin.org>",
 	"engines": { "node": ">= 0.4" },
-	"main": "ctype.js"
+	"main": "ctype.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/rmustacc/node-ctype.git"
+	}
 }


### PR DESCRIPTION
It's absence causes warnings in newer versions of npm
