### PR TITLE
Fixes #51: add licenses to package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,8 +3,11 @@ Each file specified below has its license information embedded in it:
 
 tools/jsstyle
 
+The MIT License (MIT)
+
 Copyright 2011, Robert Mustacchi. All rights reserved.
 Copyright 2011, Joyent, Inc. All rights reserved.
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
 deal in the Software without restriction, including without limitation the

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
 	"description": "read and write binary structures and data types",
 	"homepage": "https://github.com/rmustacc/node-ctype",
 	"author": "Robert Mustacchi <rm@fingolfin.org>",
+    "licenses": [{
+        "type": "MIT",
+        "url": "https://github.com/caolan/async/raw/master/LICENSE"
+    }],
 	"engines": { "node": ">= 0.4" },
 	"main": "ctype.js",
 	"repository": {


### PR DESCRIPTION
Allow the license to be determined programatically by including it in package.json; including standard wording at top of LICENSE file.
